### PR TITLE
Update nginx.conf

### DIFF
--- a/nginx/debian/conf/nginx.conf
+++ b/nginx/debian/conf/nginx.conf
@@ -23,6 +23,7 @@ http {
 	reset_timedout_connection on;
 	# add_header X-Powered-By "EasyEngine";
 	add_header rt-Fastcgi-Cache $upstream_cache_status;
+	add_header "X-UA-Compatible" "IE=Edge";
 
 	# Limit Request
 	limit_req_status 403;
@@ -44,6 +45,14 @@ http {
 	ssl_prefer_server_ciphers on;
 	ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+	
+	# Strong forward secrecy (ECDHE) for all connections, but blocks IE8+XP and Android 2.3.
+	# ssl_ciphers 'kEECDH+ECDSA+AES128 kEECDH+ECDSA+AES256 kEECDH+AES128 kEECDH+AES256 +SHA !aNULL !eNULL !LOW !MD5 !EXP !DSS !PSK !SRP !kECDH !CAMELLIA !RC4 !SEED';
+	
+	ssl_stapling on;
+	ssl_stapling_verify on;
+	resolver 8.8.4.4 8.8.8.8 valid=300s;
+	resolver_timeout 10s;
 
 	##
 	# Basic Settings
@@ -57,7 +66,7 @@ http {
 	##
 	# Logging Settings
 	##
-
+	
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;
 
@@ -76,7 +85,9 @@ http {
 	gzip_vary on;
 	gzip_proxied any;
 	gzip_comp_level 6;
+	gzip_min_length 256; 
 	gzip_buffers 16 8k;
+	# Cloudfront users should change gzip_http_version 1.1 to 1.0;
 	gzip_http_version 1.1;
 	gzip_types
 	    application/atom+xml
@@ -96,7 +107,7 @@ http {
 	    text/x-component
 	    text/xml
 	    text/javascript;
-
+	
 	##
 	# Virtual Host Configs
 	##


### PR DESCRIPTION
1) X-UA-Compatible: https://msdn.microsoft.com/library/jj676915%28v=vs.85%29.aspx
2) Alternative for ssl_ciphers to avoid weak ciphers and get better score on SSL tests.
3) OCSP stapling to improve the performance of SSL;
4) gzip_min_length 256, so you don't compress anything that's already small;
5) Note for Cloudfront users.
